### PR TITLE
Enables automatic generation of telemeter data

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -316,14 +316,25 @@ The `TLSConfig` resource configures the settings for TLS connections.
 
 #### Description
 
-The `TelemeterClientConfig` resource defines settings for the `telemeter-client` component.
+`TelemeterClientConfig` defines settings for the Telemeter Client component.
 
+#### Required
+   - ` clusterID `
+   - ` enabled `
+   - ` nodeSelector `
+   - ` telemeterServerURL `
+   - ` token `
+   - ` tolerations `
 
 <em>appears in: [ClusterMonitoringConfiguration](#clustermonitoringconfiguration)</em>
 
 | Property | Type | Description |
 | -------- | ---- | ----------- |
+| clusterID | string | Unique identifier of the cluster, that will identify the telemeter data send to RedHat |
+| enabled | *bool | Enable or disable the telemeter client |
 | nodeSelector | map[string]string | Defines the nodes on which the pods are scheduled. |
+| telemeterServerURL | string | URL of the telemeter server to send telemeter data to |
+| token | string | Token to authenticate against the telemeter server |
 | tolerations | [][v1.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#toleration-v1-core) | Defines tolerations for the pods. |
 
 [Back to TOC](#table-of-contents)

--- a/Documentation/openshiftdocs/modules/telemeterclientconfig.adoc
+++ b/Documentation/openshiftdocs/modules/telemeterclientconfig.adoc
@@ -9,8 +9,15 @@
 
 === Description
 
-The `TelemeterClientConfig` resource defines settings for the `telemeter-client` component.
+`TelemeterClientConfig` defines settings for the Telemeter Client component.
 
+=== Required
+* `clusterID`
+* `enabled`
+* `nodeSelector`
+* `telemeterServerURL`
+* `token`
+* `tolerations`
 
 
 Appears in: link:clustermonitoringconfiguration.adoc[ClusterMonitoringConfiguration]
@@ -18,7 +25,15 @@ Appears in: link:clustermonitoringconfiguration.adoc[ClusterMonitoringConfigurat
 [options="header"]
 |===
 | Property | Type | Description 
+|clusterID|string|Unique identifier of the cluster, that will identify the telemeter data send to RedHat
+
+|enabled|*bool|Enable or disable the telemeter client
+
 |nodeSelector|map[string]string|Defines the nodes on which the pods are scheduled.
+
+|telemeterServerURL|string|URL of the telemeter server to send telemeter data to
+
+|token|string|Token to authenticate against the telemeter server
 
 |tolerations|[]v1.Toleration|Defines tolerations for the pods.
 

--- a/pkg/manifests/config.go
+++ b/pkg/manifests/config.go
@@ -172,15 +172,6 @@ func (e *EtcdConfig) IsEnabled() bool {
 	return *e.Enabled
 }
 
-type TelemeterClientConfig struct {
-	ClusterID          string            `json:"clusterID"`
-	Enabled            *bool             `json:"enabled"`
-	TelemeterServerURL string            `json:"telemeterServerURL"`
-	Token              string            `json:"token"`
-	NodeSelector       map[string]string `json:"nodeSelector"`
-	Tolerations        []v1.Toleration   `json:"tolerations"`
-}
-
 func (cfg *TelemeterClientConfig) IsEnabled() bool {
 	if cfg == nil {
 		return false

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -206,6 +206,23 @@ type OpenShiftStateMetricsConfig struct {
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
 }
 
+// `TelemeterClientConfig` defines settings for the Telemeter Client
+// component.
+type TelemeterClientConfig struct {
+	// Unique identifier of the cluster, that will identify the telemeter data send to RedHat
+	ClusterID string `json:"clusterID"`
+	// Enable or disable the telemeter client
+	Enabled   *bool  `json:"enabled"`
+	// Defines the nodes on which the pods are scheduled.
+	NodeSelector       map[string]string `json:"nodeSelector"`
+	// URL of the telemeter server to send telemeter data to
+	TelemeterServerURL string            `json:"telemeterServerURL"`
+	// Token to authenticate against the telemeter server
+	Token              string            `json:"token"`
+	// Defines tolerations for the pods.
+	Tolerations []v1.Toleration `json:"tolerations"`
+}
+
 // The `ThanosQuerierConfig` resource defines settings for the Thanos Querier
 // component.
 type ThanosQuerierConfig struct {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
