### PR TITLE
Only 'tolerations' and 'nodeSelector' for TelemeterConfig

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -330,11 +330,7 @@ The `TLSConfig` resource configures the settings for TLS connections.
 
 | Property | Type | Description |
 | -------- | ---- | ----------- |
-| clusterID | string | Unique identifier of the cluster, that will identify the telemeter data send to RedHat |
-| enabled | *bool | Enable or disable the telemeter client |
 | nodeSelector | map[string]string | Defines the nodes on which the pods are scheduled. |
-| telemeterServerURL | string | URL of the telemeter server to send telemeter data to |
-| token | string | Token to authenticate against the telemeter server |
 | tolerations | [][v1.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#toleration-v1-core) | Defines tolerations for the pods. |
 
 [Back to TOC](#table-of-contents)

--- a/Documentation/openshiftdocs/modules/telemeterclientconfig.adoc
+++ b/Documentation/openshiftdocs/modules/telemeterclientconfig.adoc
@@ -25,15 +25,7 @@ Appears in: link:clustermonitoringconfiguration.adoc[ClusterMonitoringConfigurat
 [options="header"]
 |===
 | Property | Type | Description 
-|clusterID|string|Unique identifier of the cluster, that will identify the telemeter data send to RedHat
-
-|enabled|*bool|Enable or disable the telemeter client
-
 |nodeSelector|map[string]string|Defines the nodes on which the pods are scheduled.
-
-|telemeterServerURL|string|URL of the telemeter server to send telemeter data to
-
-|token|string|Token to authenticate against the telemeter server
 
 |tolerations|[]v1.Toleration|Defines tolerations for the pods.
 

--- a/pkg/manifests/types.go
+++ b/pkg/manifests/types.go
@@ -209,16 +209,16 @@ type OpenShiftStateMetricsConfig struct {
 // `TelemeterClientConfig` defines settings for the Telemeter Client
 // component.
 type TelemeterClientConfig struct {
-	// Unique identifier of the cluster, that will identify the telemeter data send to RedHat
+	// OmitFromDoc
 	ClusterID string `json:"clusterID"`
-	// Enable or disable the telemeter client
-	Enabled   *bool  `json:"enabled"`
+	// OmitFromDoc
+	Enabled *bool `json:"enabled"`
 	// Defines the nodes on which the pods are scheduled.
-	NodeSelector       map[string]string `json:"nodeSelector"`
-	// URL of the telemeter server to send telemeter data to
-	TelemeterServerURL string            `json:"telemeterServerURL"`
-	// Token to authenticate against the telemeter server
-	Token              string            `json:"token"`
+	NodeSelector map[string]string `json:"nodeSelector"`
+	// OmitFromDoc
+	TelemeterServerURL string `json:"telemeterServerURL"`
+	// OmitFromDoc
+	Token string `json:"token"`
 	// Defines tolerations for the pods.
 	Tolerations []v1.Toleration `json:"tolerations"`
 }


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG if this affects the end user!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Monitoring <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR
    <Component> Component affected by your changes such as deps bump, alerts changes and any user facing changes.

    Example:
    - [#741](https://github.com/openshift/cluster-monitoring-operator/pull/741) Bump thanos components to v0.11.0 release
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] No user facing changes, so no entry in CHANGELOG was needed.
